### PR TITLE
Update bctool.py -- bug fix and csv output option

### DIFF
--- a/code/bctool.py
+++ b/code/bctool.py
@@ -8,15 +8,12 @@
 This module provides support for auditing of a single plurality contest
 over multiple jurisdictions using a Bayesian ballot-level
 comparison audit.
-
 (See github.com/ron-rivest/2018-bptool/ for similar code for
 a Bayesian ballot-level polling audit.  The code here was based
 in part on that code.)
-
 This module provides routines for computing the winning probabilities
 for various choices, given audit sample data.  Thus, this program
 provides a risk-measuring functionality.
-
 More precisely, the code builds a Bayesian model of the unsampled
 ballots, given the sampled ballots.  This model is probabilistic,
 since there is uncertainty about what the unsampled ballots are.
@@ -24,77 +21,53 @@ However, the model is generative: we generate many possible
 sets of likely unsampled ballots, and report the probability that
 various choices win the contest.  (See References below for
 more details.)
-
 The main output of the program is a report on the probability
 that each choice wins, in these simulations.
-
 The contest may be single-jurisdiction or multi-jurisdiction.
 More precisely, we assume that there are a number of "collections"
 of ballots that may be sampled.  Each relevant jurisdiction may
 have one or more such collections.  For example, a jurisdiction
 may be a county, with one collection for ballots submitted by
 mail, and one collection for ballots cast in-person.
-
 This module may be used for ballot-polling audits (where there
 no reported choices for ballots) or "hybrid" audits (where some
 collections have reported choices for ballots, and some have not).
-
-
 To use this program from the command line, give a command like
-
         python3 bctool.py collections.csv reported.csv sample.csv
-
     where
-
         python3            is the python3 interpreter on your system
                            (this might be just called "python")
                            Besides being python3, your installation must
                            include the numpy package.  Anaconda provides
                            an excellent installation framework that
                            includes numpy.
-
         collections.csv    is the path to a file giving the number of (cast)
                            votes in each collection.
-
         reported.csv       is the path to a file giving the reported number of
                            votes for each choice in each collection.
-
         sample.csv         is the path to a file giving the number of
-
                                     (reported choice, actual choice)
-
                            pairs in the sample for each collection.  Here the
                            reported choice is the choice that the scanner
                            reported to have been on the ballot; the actual
                            choice is the choice revealed by a manual
                            examination of the ballot.
-
-
 FILE FORMATS are as follows; all are CSV files with one header line, then
 a number of data lines.
-
-
 COLLECTIONS.CSV format:
-
     Example collections.csv file:
-
         Collection,      Votes,      Comment
         Bronx,           11000
         Queens,         120000
         Mail-In,         56000
-
     with one header line, as shown, then one data line for
     each collection of paper ballots that may be sampled.
     Each data line gives the name of the collection and
     then the number of cast votes in that collection
     (that is, the number of cast paper ballots in the collection).
     An additional column for optional comments is provided.
-
-
 REPORTED.CSV format
-
     Example reported.csv file:
-
         Collection,  Reported,    Votes,       Comment
         Bronx,       Yes,          8500
         Bronx,       No,           2500
@@ -103,35 +76,26 @@ REPORTED.CSV format
         Mail-In,     Yes,          5990
         Mail-In,     No,          50000
         Mail-In,     Overvote,       10
-
     with one header line, as shown, then one data line for each
     collection and each reported choice in that collection,
     giving the number of times such reported choice is reported
     to have appeared.  An additional column for optional comments is
     provided.
-
     A reported choice need not be listed, if it occurred zero times,
     although every possible choice (except write-ins) should be listed
     at least once for some contest, so that this program knows what the
     possible votes are for this contest.
-
     For each collection, the sum, over reported choices,  of the Votes given
     should equal the Votes value given in the corresponding line in
     the collections.csv file.
-
     Write-ins may be specified as desired, perhaps with a string
     such as "Write-in:Alice Jones".
-
     For ballot-polling audits, use a reported choice of "-MISSING"
     or "-noCVR" or any identifier starting with a "-".  (Tagging
     the identifier with an initial "-" prevents it from becoming
     elegible for winning the contest.)
-
-
 SAMPLE.CSV format:
-
     Example:
-
         Collection,  Reported,  Actual,    Votes,       Comment
         Bronx,       Yes,       Yes,         62
         Bronx,       No,        No,          21
@@ -142,62 +106,45 @@ SAMPLE.CSV format:
         Mail-In,     No,        No,          73
         Mail-In,     No,        Lizard People, 2
         Mail-In,     No,        Lizard People, 1
-
     with one header line, as shown then at least one data line for
     each collection for each reported/actual choice pair that was seen
     in the audit sample at least once, giving the number of times it
     was seen in the sample.  An additional column for comments is
     provided.
-
     There is no need to give a data line for a reported/actual pair
     that wasn't seen in the sample.
-
     If you give more than one data line for a given collection,
     reported choice, and actual choice combination, then the votes
     are summed. (So the mail-in collection has three ballots the scanner said
     showed "No", but that the auditors said actually showed "Lizard
     People".)  For example, you may give one line per audited ballot,
     if you wish.
-
     The lines of this file do not need to be in any particular order.
     You can just add more lines to the end of this file as the audit
     progresses, if you like.
-
     The Reported choices must have appeared in
     the reported.csv file; the actual choices may be anything.
-
     As the audit progresses, the file sample.csv will change, but the
     other two files should not.  Only the file sample.csv has data
     obtained from manually auditing a random sample of the paper
     ballots.
-
     It is assumed here that sampling is done without replacement.
-
     This module does not assume that each collection is sampled at the
     same rate --- the audit might look at 1% of the ballots in the
     Bronx collection while looking at 2% of the ballots in the Queens
     collection.  A Bayesian audit can easily work with such
     differences in sampling rates.
-
     (The actual sampling rates are presumed to be determined by other
     modules; the present module only computes winning probabilities
     based on the sample data obtained so far.)
-
-
 There are optional parameters as well, to see their documentation,
 give command
-
     python bctool.py --h
-
 Like github.com/ron-rivest/audit-lab, the Bayesian model defaults
 to using a prior pseudocount of
-
     +1   for each (reported, actual) pair of choices (R, A) where R != A
-
     +50  for the (reported, actual) pair (R, A) of choices where R == A
-
 These default values may be changed via command-line options.
-
 This module can be used for ballot-polling audits too, if all
 reported votes are set to "-MISSING" (or some other value that
 starts with an initial "-"; even just "-" will do).  For a
@@ -205,35 +152,25 @@ hybrid audit where some collections have CVRs and some do not,
 it suffices to use the reported choice "-MISSING" for ballots
 in those collections not having CVRs, and to the available
 reported choice otherwise.
-
-
 If this module is imported by another python module,
 rather than used stand-alone from the command line, then
 the procedure
-
     compute_win_probs
-
 can compute the desired probability of each choice winning a full
 manual tally, given the sample tallies for each collection.
-
-
 More description of Bayesian auditing methods can be found in:
-
     A Bayesian Method for Auditing Elections
     by Ronald L. Rivest and Emily Shen
     EVN/WOTE'12 Proceedings (2012)
     http://people.csail.mit.edu/rivest/pubs.html#RS12z
-
     Bayesian Tabulation Audits: Explained and Extended
     by Ronald L. Rivest
     (2018)
     http://people.csail.mit.edu/rivest/pubs.html#Riv18a
-
     Bayesian Election Audits in One Page
     by Ronald L. Rivest
     (2018)
     http://people.csail.mit.edu/rivest/pubs.html#Riv18b
-
 """
 
 import argparse
@@ -252,7 +189,6 @@ import numpy as np
 def duplicates(L):
     """
     Return a list of the duplicates occurring in a given list L.
-
     If there are no duplicates, return empty list.
     """
 
@@ -294,16 +230,11 @@ def convert_int_to_32_bit_numpy_array(v):
     since this format is needed to initialize a numpy.random.RandomState
     object.  More precisely, the result is a numpy array of type int64,
     but each value is between 0 and 2**32-1, inclusive.
-
     Example: input 2**64 + 5 yields np.array([5, 0, 1], dtype=int)
-
     Input Parameters:
-
         v         -- an integer, representing the audit seed that's being
                      passed in. We expect v to be non-negative.
-
     Returns:
-
         numpy array  -- created deterministically from v that will
                         be used to initialize the Numpy RandomState.
     """
@@ -320,7 +251,7 @@ def convert_int_to_32_bit_numpy_array(v):
         v_parts.append(v % radix)
         v = v // radix
     # note: v_parts will be empty list if v==0, that is OK
-    return np.array(v_parts, dtype=int)
+    return np.array(v_parts, dtype=np.int64)
 
 
 def create_rs(seed):
@@ -328,15 +259,11 @@ def create_rs(seed):
     Create and return a Numpy RandomState object for a given seed.
     The input seed should be a python integer, arbitrarily large.
     The purpose of this routine is to make all the audit actions reproducible.
-
     Input Parameters:
-
         seed              -- an integer or None.
                              Assuming that it isn't None, we
                              convert it into a Numpy Array.
-
     Returns:
-
         a Numpy RandomState object  --  based on the seed, or the clock
                                         time if the seed is None.
     """
@@ -353,7 +280,6 @@ def create_rs(seed):
 def parse_args():
     """
     Parse command-line arguments and return resulting 'args' object.
-
     """
 
     parser = argparse.ArgumentParser(
@@ -424,6 +350,10 @@ def parse_args():
                         type=int,
                         default=1)
 
+    parser.add_argument("--csv_output_filename",
+                        help="Designate a filename for the results to be provided in CSV format.",
+                        default="")
+
     parser.add_argument("--v", "--verbose",
                         help="Verbose output.",
                         action='store_true')
@@ -440,12 +370,10 @@ def parse_args():
 def read_csv(path_to_csv, expected_fieldnames):
     """
     Read CSV file and return list of dicts representing rows.
-
     Fieldnames have leading/trailing blanks removed, and are
     lower-cased.
     Values are converted to type "int" whenever possible.
     Checks that field names are exactly as expected.
-
     """
 
     with open(path_to_csv) as csv_file:
@@ -483,17 +411,11 @@ def read_csv(path_to_csv, expected_fieldnames):
 def read_and_process_collections(path_to_collections_file):
     """
     Return list of collection names and dict mapping names to sizes.
-
     Input:
-
         path_to_collections_file     -- (string) path to collections.csv file
-
     Output:
-
         collection_names             -- list of all collection names
-
         collection_size              -- dict mapping collection names to sizes
-
     """
 
     collections_rows = read_csv(path_to_collections_file,
@@ -519,18 +441,14 @@ def read_and_process_reported(path_to_reported_file,
                               path_to_collections_file):
     """
     Read and process file for reported vote totals.
-
     Input:
-
         path_to_reported_file    -- (string) path to reported.csv file
         collection_names         -- list of all collection names
         collection_size          -- mapping: collection_name ->
                                              size (number of votes cast)
         path_to_collections_file -- (string) path to collections.csv
                                     file
-
     Returns:
-
         reported_choices        -- list of reported choices, over all
                                    collections, sorted into order
                                    alphabetically
@@ -595,24 +513,17 @@ def read_and_process_sample(path_to_sample_file,
                             reported_choices):
     """
     Read sample.csv file and process it.
-
     Input:
-
         path_to_sample_file         -- (string) path to input sample.csv
-
         collection_names            -- list of collection names
-
         reported_choices            -- list of reported choices
                                        (from reported.csv)
-
     Return:
-
         actual_choices              --  list of all actual choices,
                                         plus all reported choices
                                         (ones that don't start with
                                         an initial "-"),
                                         sorted into in alphabetical order
-
         sample_dict                 --  nested mapping of dicts:
                                         collection_name -> reported_choice ->
                                             actual_choice -> votes
@@ -671,36 +582,28 @@ def dirichlet_multinomial(
     stratum_sample_tally, so the returned tally sums to stratum_size.
     This routine is equivalent to the "Restore" procedure described
     in the "Bayesian Election Audits in One Page" note cited above.
-
     Input Parameters:
-
          stratum_sample_tally  -- a list of integers, where the i'th element
                                   is the number of votes that choice i received
                                   in the sample.
                                   (Here i indexes into actual_choices.)
-
          stratum_pseudocounts -- a list of integers of exactly the same length
                                  as stratum_sample_tally, giving as the i-th
                                  element the Bayesian pseudocount for the i-th
                                  choices, as a way of defining the prior.
-
          stratum size         -- an integer equal to the number of
                                  votes cast in this contest in this stratum.
-
          rs                   -- a Numpy RandomState object that is used for
                                  any random functions in the simulation of
                                  the nonsample votes. In particular,
                                  the gamma functions are made deterministic
                                  using this state.
-
     Returns:
-
         multinomial_sample       -- a list of integers, which sums up
                                     to (stratum_size - stratum_sample_size).
                                     The i'th element is equal to the
                                     simulated number of votes for choice i in
                                     the remaining, unsampled votes.
-
     """
 
     stratum_sample_size = sum(stratum_sample_tally)
@@ -735,28 +638,21 @@ def generate_restored_sample_tally(stratum_sample_tally,
     Given a stratum_sample_tally, a stratum_prior (expressed as pseudocounts),
     the stratum_size, and a seed,  generate a restored_sample_tally in the
     contest using the Dirichlet multinomial distribution.
-
     Input Parameters:
-
          stratum_sample_tally  -- a list of integers, where the i'th index in
                                   sample_tally corresponds to the number of
                                   votes that choice i received in the sample.
                                   (Here i indexes into actual_choices.)
-
          stratum_pseudocounts -- a list of integers of exactly the same length
                                  as stratum_sample_tally, giving as the i-th
                                  element the Bayesian pseudocount for the i-th
                                  choices, as a way of defining the prior.
-
          stratum size         -- an integer equal to the number of
                                  votes cast in this contest in this stratum.
-
          seed                 -- an integer or None. Assuming that it isn't
                                  None, we use it to seed the random state
                                  for the audit.
-
     Returns:
-
         restored_sample_tally -- a list of integers, which sums up
                                  to  total_num_votes.
                                  The i'th index represents the simulated
@@ -789,9 +685,7 @@ def compute_winner(strata_sample_tallies,
     generate a restored_sample_tally. Then, we sum over all the collections
     to produce our final tally and calculate the predicted winner(s) over
     all the collections in the contest.
-
     Input Parameters:
-
         strata_sample_tallies    -- a list of lists. Each list is
                                     a stratum sample tally.
                                     So, strata_sample_tallies[i]
@@ -799,20 +693,16 @@ def compute_winner(strata_sample_tallies,
                                     Then, strata_sample_tallies[i][j]
                                     represents the number of votes choice j
                                     receives in stratum i.
-
         strata_pseudocounts      -- a list of lists, same shape as
                                     strata_sample_tallies.
                                     i-th element gives pseudocounts
                                     for i-th stratum.
-
         total_num_votes          -- a list whose i-th element is an integer
                                     equal to the number of ballots that were
                                     cast in this contest in the i-th stratum.
-
         seed                     -- an integer or None. Assuming that it
                                     isn't None, we use it to seed the random
                                     state for the audit.
-
         n_winners                -- an integer, parsed from command-line args.
                                     Its default value is 1, which means we only
                                     calculate a single winner for the contest.
@@ -820,14 +710,11 @@ def compute_winner(strata_sample_tallies,
                                     the unnsampled votes and define a win for
                                     choice i as any time they are in the top
                                     n_winners choices in the final tally.
-
         pretty_print             -- a Boolean, which defaults to False.
                                     When True, we print the winning choice,
                                     the number of votes it received and the
                                     final vote tally for all the choices.
-
     Returns:
-
         winner                   -- an integer, representing the index of the
                                     choice that won the contest.
     """
@@ -873,14 +760,11 @@ def compute_win_probs(strata_sample_tallies,
     """
     Run num_trials simulations of the Bayesian audit to estimate
     the probability that each candidate would win a full recount.
-
     In particular, we run a single iteration of a Bayesian audit
     (extend each collection's sample to simulate all the votes in the
     collection and calculate the overall winner across counties)
     num_trials times.
-
     Input Parameters:
-
         strata_sample_tallies  -- a list of lists. Each list represents
                                   the sample tally for a given collection.
                                   So, sample_tallies[i] represents the
@@ -888,29 +772,23 @@ def compute_win_probs(strata_sample_tallies,
                                   sample_tallies[i][j] represents the
                                   number of votes choice j receives in
                                   collection i.
-
         strata_pseudocounts    -- an array of the same shape as
                                   strata_sample_tallies;
                                   the i-th element of this array gives
                                   the Bayesian prior in the form of
                                   pseudocounts.
-
         total_num_votes        -- an integer representing the number of
                                   ballots that were cast in this contest
-
         seed                   -- an integer or None. Assuming that it isn't
                                   None, we use it to seed the random state
                                   for the audit.
-
         num_trials             -- an integer which represents how many
                                   simulations of the Bayesian audit trial
                                   we run to estimate the win probabilities
                                   of the choices.
-
         actual_choices         -- an ordered list of strings, containing
                                   the name of every choice in the contest
                                   being audited.
-
         n_winners              -- an integer, parsed from the command-line
                                   args. Its default value is 1, which means
                                   we only calculate a single winner for the
@@ -919,9 +797,7 @@ def compute_win_probs(strata_sample_tallies,
                                   the unnsampled votes and define a win for
                                   choice i as any time they are in the top
                                   n_winners choices in the final tally.
-
     Returns:
-
         win_probs              -- a list of pairs (i, p) where p is the
                                   fractional representation of the number
                                   of trials that candidate i has won
@@ -955,19 +831,15 @@ def print_results(actual_choices, win_probs, n_winners):
     """
     Given list of all choices and win_probs pairs, print summary
     of the Bayesian audit simulations.
-
     Input Parameters:
-
         actual_choices              -- an ordered list of strings,
                                        containing the name of every choice
                                        reported or seen in the contest
                                        we are auditing.
-
         win_probs                   -- a list of pairs (i, p) where p is
                                        the fractional representation of the
                                        number of trials that choice i has
                                        won out of the num_trials simulations.
-
         n_winners                   -- an integer, parsed from the command
                                        line. Its default value is 1, which
                                        means we only calculate a single
@@ -977,9 +849,7 @@ def print_results(actual_choices, win_probs, n_winners):
                                        define a win for choice i as any trial
                                        it is in the top n_winners choices in
                                        the final tally.
-
     Returns:
-
         None                        -- but prints a summary of how often each
                                        choice has won in the simulations.
     """
@@ -1008,7 +878,38 @@ def print_results(actual_choices, win_probs, n_winners):
         choice_name = str(actual_choices[choice_index - 1])
         print(" {:<24s} \t  {:6.2f} %  "
               .format(choice_name, 100*prob))
+              
 
+def output_results(actual_choices, win_probs, n_winners, csv_output_filename):
+    """
+    Given list of all choices and win_probs pairs, produce csv file
+    providing the output, as follows:
+    
+    Input Parameters:
+        actual_choices              -- an ordered list of strings,
+                                       containing the name of every choice
+                                       reported or seen in the contest
+                                       we are auditing.
+        win_probs                   -- a list of pairs (i, p) where p is
+                                       the fractional representation of the
+                                       number of trials that choice i has
+                                       won out of the num_trials simulations.
+ 
+    Returns:
+        None                        -- but creates the csv file and writes the results.
+    """
+
+    with open(csv_output_filename, mode='w') as csvoutput_file:
+        csvoutput_writer = csv.writer(csvoutput_file, delimiter=',', 
+            quotechar='"', 
+            quoting=csv.QUOTE_MINIMAL,
+            lineterminator="\n")
+
+        csvoutput_writer.writerow(['choice', 'winprob'])
+        for choice_index, prob in win_probs:
+            choice_name = str(actual_choices[choice_index - 1])
+            csvoutput_writer.writerow([choice_name, prob])
+              
 
 def main():
     """
@@ -1093,7 +994,11 @@ def main():
                     actual_choices,
                     args.n_winners)
 
-    print_results(actual_choices, win_probs, args.n_winners)
+    if args.csv_output_filename : 
+        output_results(actual_choices, win_probs, args.n_winners,
+                    args.csv_output_filename)    
+    else :
+        print_results(actual_choices, win_probs, args.n_winners)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Corrected bug in convert_int_to_32_bit_numpy_array(v)
dtype in return conversion was "int", should have been np.int64
Corrected error which arose when run on windows platform but did not surface on Linux platforms.
Also added --csv_output_filename option to allow silent output to a csv formatted file.
This provides the mechanism to allow other programs to call this one and interact with the intervening files.